### PR TITLE
Fixed usePage type

### DIFF
--- a/stubs/inertia-react-ts/resources/ts/Components/DangerButton.tsx
+++ b/stubs/inertia-react-ts/resources/ts/Components/DangerButton.tsx
@@ -7,7 +7,7 @@ interface Props {
     onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
-// export default function DangerButton({ type = 'submit', className = '', processing, children, onClick }: Props) {
+
 export default function DangerButton({ className = '', disabled, children, ...props }: Props) {
     return (
         <button

--- a/stubs/inertia-react-ts/resources/ts/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
+++ b/stubs/inertia-react-ts/resources/ts/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
@@ -25,7 +25,7 @@ interface InertiaPage extends Page<PageProps> {
 }
 
 export default function UpdateProfileInformation({ mustVerifyEmail, status, className, }: Props) {
-    const user = usePage<InertiaPage>().props.auth.user;
+    const user = usePage<InertiaPage & { [key: string]: any }>().props.auth.user;
 
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
         name: user.name,


### PR DESCRIPTION
This fixes the type of the usePage hook provided by Inertia by adding `& { [key: string]: any }`, indicating that it can have additional properties of any type with string keys.
